### PR TITLE
Add hashtags to href

### DIFF
--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -52,13 +52,13 @@ const AboutPage = ({ data }) => {
       <section className={AboutStyles.keyMoments}>
         <h3 className={AboutStyles.full}>Key Moments</h3>
 
-        <div className={AboutStyles.keyMoment1}>Sole creator of a webapp shown to the CEO directly by my VP that secured additional funding to the design team<a href="citation-1">¹</a></div>
+        <div className={AboutStyles.keyMoment1}>Sole creator of a webapp shown to the CEO directly by my VP that secured additional funding to the design team<a href="#citation-1">¹</a></div>
 
-        <div className={AboutStyles.keyMoment2}>Branding a company’s entire yearly conference<a href="citation-2">²</a></div>
+        <div className={AboutStyles.keyMoment2}>Branding a company’s entire yearly conference<a href="#citation-2">²</a></div>
 
-        <div className={AboutStyles.keyMoment3}>My conference work being an inspiration to others, notably Font Style Matcher<a href="citation-3">³</a></div>
+        <div className={AboutStyles.keyMoment3}>My conference work being an inspiration to others, notably Font Style Matcher<a href="#citation-3">³</a></div>
 
-        <div className={AboutStyles.keyMoment4}>Designing the initial tooling for CSS Grid, subsequently studied by all other major browsers for their own implementations<a href="citation-4">⁴</a></div>
+        <div className={AboutStyles.keyMoment4}>Designing the initial tooling for CSS Grid, subsequently studied by all other major browsers for their own implementations<a href="#citation-4">⁴</a></div>
 
         <div className={AboutStyles.keyMomentCitations}>
           <span id="citation-1">¹ Rich Fairbanks, Capital One</span> <br />


### PR DESCRIPTION
Without the hashtags they open new pages => 404

Anchor links don't work on chrome, tried this but didn't have much success  😔
https://github.com/gatsbyjs/gatsby/issues/386#issuecomment-249463446

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->
